### PR TITLE
Regex improvement

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from praw.models import Comment, Submission
 
 AMP_REGEX = re.compile(
-    r"http.?://(|.+\.)(?<!(developer)\.)google.[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
+    r"http.?://(|.+\.)(?<!(developer)\.)google\.[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
     #r"google[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
 )  # https://regex101.com/r/92WOyk/1
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from praw.models import Comment, Submission
 
 AMP_REGEX = re.compile(
-    r"http.?://(|.+\.)(?<!(developer)\.)google\.[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
+    r"http(|s)://(|.+\.)(?<!(developer)\.)google\.[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
     #r"google[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
 )  # https://regex101.com/r/92WOyk/1
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,8 @@ from bs4 import BeautifulSoup
 from praw.models import Comment, Submission
 
 AMP_REGEX = re.compile(
-    r"google[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
+    r"http.?://(|.+\.)(?<!(developer)\.)google.[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
+    #r"google[a-z.]+/amp/(?:s/)?(.*)", re.IGNORECASE | re.MULTILINE
 )  # https://regex101.com/r/92WOyk/1
 
 


### PR DESCRIPTION
RE: #2
New string: `http.?://(|.+\.)(?<!(developer)\.)google\.[a-z.]+/amp/(?:s/)?(.*)`
Matches both `http://` and `https://`, as well as any subdomain, including none (`https://google.com`), EXCEPT `https://developer.google.com`.
Additionally, added literal `.` to the end of the second level domain, so that `google.com/amp` is matched, but `googlehax.com/amp` is not.